### PR TITLE
Set bash -e as build node shell command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,25 +21,25 @@ node("docker") {
                 --env https_proxy=${env.https_proxy} \
             ")
         sh "docker cp ${project} ${container_name}:/home/jenkins/${project}"
-        sh """docker exec --user root ${container_name} bash -c \"
+        sh """docker exec --user root ${container_name} bash -e -c \"
             chown -R jenkins.jenkins /home/jenkins/${project}
         \""""
-        
+
         stage("Install virtualenv") {
-            sh """docker exec -u root ${container_name} bash -c \"
-               yum install -y python-virtualenv 
+            sh """docker exec -u root ${container_name} bash -e -c \"
+               yum install -y python-virtualenv
             \""""
         }
 
         stage("Create virtualenv") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 virtualenv build_env
             \""""
         }
-        
+
         stage("Install requirements") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 source build_env/bin/activate
                 build_env/bin/pip --proxy ${http_proxy} install --upgrade pip
@@ -48,15 +48,15 @@ node("docker") {
         }
 
         stage("Run test coverage") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 source build_env/bin/activate
                 build_env/bin/coverage xml DonkiDirector/*.py
             \""""
             sh "docker cp ${container_name}:/home/jenkins/${project} ./"
             sh "ls *"
-            
-            
+
+
             dir("${project}") {
                 sh "ls *"
                 step([


### PR DESCRIPTION
This makes scripts exit with an error after the first failing command
and does not require using && to continue lines in scripts.